### PR TITLE
Require contract to be paused when updating

### DIFF
--- a/contracts/PalmEcosystemVestingWallet.sol
+++ b/contracts/PalmEcosystemVestingWallet.sol
@@ -40,7 +40,7 @@ contract PalmEcosystemVestingWallet is Ownable, Pausable, VestingWallet {
         return currentBeneficiary;
     }
 
-    function setBeneficiary(address newBeneficiary) external onlyOwner {
+    function setBeneficiary(address newBeneficiary) external onlyOwner whenPaused {
         require(newBeneficiary != address(0), "Beneficiary is zero address");
         require(newBeneficiary != currentBeneficiary, "New beneficiary must differ from current beneficiary");
         address prevBeneficiary = currentBeneficiary;
@@ -52,7 +52,7 @@ contract PalmEcosystemVestingWallet is Ownable, Pausable, VestingWallet {
         return currentDuration;
     }
 
-    function setDuration(uint64 newDuration) external onlyOwner {
+    function setDuration(uint64 newDuration) external onlyOwner whenPaused {
         require(newDuration != currentDuration, "New duration must differ from current duration");
         uint64 prevDuration = currentDuration;
         currentDuration = newDuration;


### PR DESCRIPTION
### Description
 In order to minimize the risk of an unintended or incorrect update, require the contract to be paused when updating the duration or beneficiary values.  This makes updates safer, preventing the following mistakes:
* Setting the wrong beneficiary while unpaused could allow the mistaken beneficiary to withdraw funds immediately.
* Decreasing or setting the duration to 0 while unpaused could allow the funds to be immediately withdrawn.

